### PR TITLE
update: add netstandard2.0 target framework

### DIFF
--- a/Updater.cs
+++ b/Updater.cs
@@ -88,9 +88,17 @@ namespace Avantgarde.Core
                 dm.DownloadRemoteFile(AGBIN_URL, agbinDir + "agbin.zip");
                 ZipFile.ExtractToDirectory(agbinDir + "agbin.zip", agbinDir);
                 File.Delete(agbinDir + "agbin.zip");
-            }            
+            }
+
             // Move settings and file manifest to the agbin directory for launch
-            File.Move(SettingsFile.OriginalAppPath + Settings.FILES_FILENAME, agbinDir + Settings.FILES_FILENAME, true);
+            string pathToAgFiles = agbinDir + Settings.FILES_FILENAME;
+
+            if (File.Exists(pathToAgFiles))
+            {
+                File.Delete(pathToAgFiles);
+            }
+
+            File.Move(SettingsFile.OriginalAppPath + Settings.FILES_FILENAME, pathToAgFiles);
             File.Copy(SettingsFile.OriginalAppPath + Settings.SETTINGS_FILENAME, agbinDir + Settings.SETTINGS_FILENAME, true);                        
         }
 

--- a/avantgarde.lib.csproj
+++ b/avantgarde.lib.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <TargetFrameworks>netcoreapp3.0;netstandard2.0</TargetFrameworks>
     <Version>1.0.1.0</Version>
     <PackageId>avantgarde</PackageId>
     <Company>avantgarde</Company>
@@ -16,11 +16,11 @@
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
-    <DocumentationFile>C:\Users\Gab\Source\Repos\avantgarde\avantgardelib\avantgarde.lib.xml</DocumentationFile>
+    <DocumentationFile>$(ProjectDir)avantgarde.lib.xml</DocumentationFile>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">
-    <DocumentationFile>C:\Users\Gab\Source\Repos\avantgarde\avantgardelib\avantgarde.lib.xml</DocumentationFile>
+    <DocumentationFile>$(ProjectDir)avantgarde.lib.xml</DocumentationFile>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION

- added netstandard2.0 to TargetFrameworks to allow avantgarde to be built with .net core and .net standard class libraries.
- updated File.Move() method call to work with .netstandard (does not have 3 arguments; only 2)
- DocumentationFile project property now uses $(ProjectDir) instead of absolute path